### PR TITLE
Comment bos taurus chromosomes as MT not available anymore.

### DIFF
--- a/annsrcs/ensembl/bos_taurus
+++ b/annsrcs/ensembl/bos_taurus
@@ -7,7 +7,7 @@ datasetName=btaurus_gene_ensembl
 mySqlDbName=bos_taurus
 mySqlDbUrl=ensembldb.ensembl.org:5306
 types=ensgene,enstranscript,ensprotein
-chromosomeName=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,X,MT
+# chromosomeName=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,X,MT
 property.gene_biotype=gene_biotype
 property.description=description
 property.embl=embl
@@ -29,4 +29,3 @@ property.refseq=refseq_mrna,refseq_ncrna,refseq_peptide
 property.symbol=external_gene_name
 property.uniprot=uniprotsptrembl,uniprotswissprot
 arrayDesign.A-AFFY-128=affy_bovine
-


### PR DESCRIPTION
This was part of E95! and for some reason got stranded, as the error happened later on, but it was used to so it should be merged to develop.