### PR TITLE
Fix Bash syntax error and remove OSX-specific find usage

### DIFF
--- a/util/updateReleaseNumber.sh
+++ b/util/updateReleaseNumber.sh
@@ -7,7 +7,7 @@ function update {
   updateCommand="s|software.version=\d+$|software.version=${2}|"
   dir=$3
 
-  find -X $dir -type f | xargs grep -l $filterPhrase | xargs perl -pi -e $updateCommand
+   find $dir -type f -exec grep -l $filterPhrase {} \; | xargs perl -pi -e $updateCommand  
 }
 
 if [ $# -lt 4 ]; then
@@ -17,7 +17,7 @@ if [ $# -lt 4 ]; then
 fi
 scriptDir=`dirname $0`/../annsrcs
 
-if [$(git diff --name-only --cached | wc -l ) != 0 ] ; then
+if [ $(git diff --name-only --cached | wc -l ) != 0 ] ; then
  echo "Dirty worktree: "
  git diff --name-only --cached
 else


### PR DESCRIPTION
Current use of -X parameter breaks when this script is used away from OSX, so I switched to use of -exec. 

There's also a Bash error in a conditional due to a missing space which I've fixed.